### PR TITLE
feat: update 2x token addresses

### DIFF
--- a/src/lists/mainnet/index-tokens.ts
+++ b/src/lists/mainnet/index-tokens.ts
@@ -11,7 +11,7 @@ export const INDEX_COOP_MAINNET_TOKENS: TokenData[] = [
       'https://docs.indexcoop.com/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MJY-enmfAw5ra2s-8QX%2Fuploads%2FAHyFusKCIRPu5o9FhZkk%2FGMI_LOGO-07.svg?alt=media&token=536da550-6d40-4f6c-b115-3b52a6365d64',
   },
   {
-    address: '0x35AA217f55BdB014AeBF0c7527296558a2D250c2',
+    address: '0xD2AC55cA3Bbd2Dd1e9936eC640dCb4b745fDe759',
     chainId: 1,
     name: 'Index Coop Bitcoin 2x Index',
     symbol: 'BTC2X',
@@ -28,7 +28,7 @@ export const INDEX_COOP_MAINNET_TOKENS: TokenData[] = [
       'https://uploads-ssl.webflow.com/62e3ff7a08cb1968bf057388/651f04818f458f918171c84d_cdETI-logo.svg',
   },
   {
-    address: '0x31F13653433B6c48fD5B19945cD9ab20621F8d4B',
+    address: '0x65c4C0517025Ec0843C9146aF266A2C5a2D148A2',
     chainId: 1,
     name: 'Index Coop Ethereum 2x Index',
     symbol: 'ETH2X',


### PR DESCRIPTION
Updates addresses for the new redeployed tokens BTC2X and ETH2X

https://etherscan.io/token/0xD2AC55cA3Bbd2Dd1e9936eC640dCb4b745fDe759
https://etherscan.io/token/0x65c4C0517025Ec0843C9146aF266A2C5a2D148A2