### PR TITLE
feat: add get index token data by address

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {getIndexTokenData} from '../utils';
+import {getIndexTokenData, getIndexTokenDataByAddress} from '../utils';
 
 describe('getIndexTokenData', () => {
   test('returns token data for mainnet', async () => {
@@ -21,6 +21,43 @@ describe('getIndexTokenData', () => {
 
   test('returns null for non existent token', async () => {
     const data = getIndexTokenData('ETH');
+    expect(data).toBeNull();
+  });
+});
+
+describe('getIndexTokenDataByAddress', () => {
+  test('returns token data for mainnet', async () => {
+    const data = getIndexTokenDataByAddress(
+      '0xc4506022fb8090774e8a628d5084eed61d9b99ee',
+      1
+    );
+    expect(data).not.toBeNull();
+    expect(data?.symbol).toBe('hyETH');
+  });
+
+  test('returns token data for arbitrum', async () => {
+    const data = getIndexTokenDataByAddress(
+      '0x26d7D3728C6bb762a5043a1d0CeF660988Bca43C',
+      42161
+    );
+    expect(data).not.toBeNull();
+    expect(data?.address).toBe('0x26d7D3728C6bb762a5043a1d0CeF660988Bca43C');
+    expect(data?.symbol).toBe('ETH2X');
+  });
+
+  test('returns null for an unsupported chain', async () => {
+    const data = getIndexTokenData(
+      '0x26d7D3728C6bb762a5043a1d0CeF660988Bca43C',
+      11155111
+    );
+    expect(data).toBeNull();
+  });
+
+  test('returns null for non existent token', async () => {
+    const data = getIndexTokenDataByAddress(
+      '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      1
+    );
     expect(data).toBeNull();
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,10 @@
 import {IndexCoopArbitrumTokens, IndexCoopMainnetTokens, TokenData} from '..';
 
-export function getIndexTokenData(
-  symbol: string,
-  chainId = 1
-): TokenData | null {
+function isSameAddress(address1: string, address2: string): boolean {
+  return address1.toLowerCase() === address2.toLowerCase();
+}
+
+function getTokenList(chainId: number) {
   let tokenlist: TokenData[] | null = null;
   switch (chainId) {
     case 1:
@@ -13,9 +14,29 @@ export function getIndexTokenData(
       tokenlist = IndexCoopArbitrumTokens;
       break;
   }
+  return tokenlist;
+}
+
+export function getIndexTokenData(
+  symbol: string,
+  chainId = 1
+): TokenData | null {
+  const tokenlist = getTokenList(chainId);
   if (tokenlist === null) return null;
-  const tokenData = tokenlist.filter(
+  const tokenData = tokenlist.find(
     token => token.symbol.toLowerCase() === symbol.toLowerCase()
   );
-  return tokenData[0] ?? null;
+  return tokenData ?? null;
+}
+
+export function getIndexTokenDataByAddress(
+  address: string,
+  chainId: number
+): TokenData | null {
+  const tokenlist = getTokenList(chainId);
+  if (tokenlist === null) return null;
+  const tokenData = tokenlist.find(token =>
+    isSameAddress(token.address, address)
+  );
+  return tokenData ?? null;
 }


### PR DESCRIPTION
* Adds utility function for getting token data by address (and chainId) e.g. hyETH:

```typescript
 getIndexTokenDataByAddress('0xc4506022fb8090774e8a628d5084eed61d9b99ee', 1);
```